### PR TITLE
Bug/fix css display

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -10,7 +10,6 @@ import { useChangeColor } from '../utils/useChangeColor';
 export default function Home() {
   const [changeInnerColor, changeOuterColor, {innerColor, outerColor}] = useChangeColor(); 
   console.log("in: ", innerColor,  "out: ", outerColor)
-  console.log("clientID: ", process.env.GITHUB_CLIENT)
 
   return (
     <div className="min-h-screen flex flex-col justify-items-center">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,9 +1,5 @@
 module.exports = {
-  purge: [
-    "./src/pages/**/*.{ts, tsx}",
-    "./src/ui/**/*.{ts, tsx}",
-    "./src/utils/**/*.{ts, tsx}"
-  ],
+  purge: [],
 
   darkMode: false, // or 'media' or 'class'
   theme: {


### PR DESCRIPTION
## cssが正常にビルドされないバグを踏んだ
- tailwindcss:2.0.1内でのバグ
- tailwind.config.js 内のpurgeでenabledをtrue(おそらくdefault=true)だとビルドエラーが生じる模様？
- https://github.com/tailwindlabs/tailwindcss/discussions/3080　
- 上記の場でも議論されている(2020-12-18)
## とりあえずの解決策
- とりあえず、purgeを[]で一時的に凌いでいく
- 様子見ながら、修正する